### PR TITLE
ポイントが自分の方に向くように要求する範囲を修正

### DIFF
--- a/ptcs/ptcs_control/components/junction.py
+++ b/ptcs/ptcs_control/components/junction.py
@@ -133,18 +133,20 @@ class Junction(BaseComponent):
                     nearest_distance = distance
                 continue
 
-            # 一応同じ閉塞区間の次の区間まで見る
+            # 次の閉塞区間まで見る
             current_section = train.head_position.section
             current_target_junction = train.head_position.target_junction
+            block_ids: set[str | None] = set([])
             while True:
-                if current_section.block_id != train.head_position.section.block_id:
-                    break
+                block_ids.add(current_section.block_id)
                 next_section_and_target_junction = current_section.get_next_section_and_target_junction_strict(
                     current_target_junction
                 )
                 if next_section_and_target_junction is None:
                     break
                 next_section, next_target_junction = next_section_and_target_junction
+                if len(block_ids | set([next_section.block_id])) > 2:
+                    break
                 distance += next_section.length
                 if next_target_junction == self:
                     if distance < nearest_distance:
@@ -183,18 +185,20 @@ class Junction(BaseComponent):
                 trains.append(train)
                 continue
 
-            # 一応同じ閉塞区間の次の区間まで見る
+            # 次の閉塞区間まで見る
             current_section = train.head_position.section
             current_target_junction = train.head_position.target_junction
+            block_ids: set[str | None] = set()
             while True:
-                if current_section.block_id != train.head_position.section.block_id:
-                    break
+                block_ids.add(current_section.block_id)
                 next_section_and_target_junction = current_section.get_next_section_and_target_junction_strict(
                     current_target_junction
                 )
                 if next_section_and_target_junction is None:
                     break
                 next_section, next_target_junction = next_section_and_target_junction
+                if len(block_ids | set([next_section.block_id])) > 2:
+                    break
                 distance += next_section.length
                 if next_target_junction == self:
                     trains.append(train)

--- a/ptcs/ptcs_control/control/fixed_block.py
+++ b/ptcs/ptcs_control/control/fixed_block.py
@@ -90,18 +90,20 @@ class FixedBlockControl(BaseControl):
                     ):
                         junction.manual_direction = PointDirection.CURVE
                     else:
-                        # 一応同じ閉塞区間の次の区間まで見る
+                        # 次の閉塞区間まで見る
                         current_section = nearest_train.head_position.section
                         current_target_junction = nearest_train.head_position.target_junction
+                        block_ids: set[str | None] = set()
                         while True:
-                            if current_section.block_id != nearest_train.head_position.section.block_id:
-                                break
+                            block_ids.add(current_section.block_id)
                             next_section_and_target_junction = (
                                 current_section.get_next_section_and_target_junction_strict(current_target_junction)
                             )
                             if next_section_and_target_junction is None:
                                 break
                             next_section, next_target_junction = next_section_and_target_junction
+                            if len(block_ids | set([next_section.block_id])) > 2:
+                                break
                             if section_t == next_section:
                                 junction.manual_direction = PointDirection.STRAIGHT
                                 break


### PR DESCRIPTION
経堂駅で、各駅停車が C49 を踏んだときに通勤準急が B48 に居ても j120 に要求を出せておらず、各駅停車が先に発車してしまっていたため

「今居る閉塞区間の次のセクションの先にあるポイントまで見る」ではなく、「今居る閉塞区間の次の閉塞区間にあるポイントまで見る」に修正

![image](https://github.com/user-attachments/assets/8c2eaa70-7893-45e2-8ea0-eed820cc63b0)